### PR TITLE
Add support for XSRF token

### DIFF
--- a/src/channel/private-channel.ts
+++ b/src/channel/private-channel.ts
@@ -1,4 +1,5 @@
 import Channel from './channel';
+import Cookies from '../helpers/cookies';
 
 export default class PrivateChannel extends Channel {
 
@@ -28,6 +29,12 @@ export default class PrivateChannel extends Channel {
         xmlHttp.setRequestHeader('Content-Type', 'application/json');
         if (this._broadcastt.options.csrf) {
             xmlHttp.setRequestHeader('X-CSRF-TOKEN', this._broadcastt.options.csrf);
+        } else {
+            const cookies = new Cookies();
+            const token = cookies.read('XSRF-TOKEN');
+            if (token) {
+                xmlHttp.setRequestHeader('X-XSRF-TOKEN', this._broadcastt.options.csrf);
+            }
         }
         xmlHttp.onload = () => {
             if (xmlHttp.status === 200 && xmlHttp.responseText) {

--- a/src/helpers/cookies.ts
+++ b/src/helpers/cookies.ts
@@ -1,0 +1,6 @@
+export default class Cookies {
+    public read(name: string): string {
+        const match = document.cookie.match(new RegExp('(^|;\\s*)(' + name + ')=([^;]*)'));
+        return (match ? decodeURIComponent(match[3]) : null);
+    }
+}


### PR DESCRIPTION
This PR contains logic to add an `X-XSRF-TOKEN` header to the request automatically if an `XSRF-TOKEN` cookie is present in the client browser and a CSRF token was not set previously in the options.