### PR TITLE
ci: use GitHub Actions for test and publish

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,5 +11,5 @@ trim_trailing_whitespace = true
 [*.md]
 trim_trailing_whitespace = false
 
-[{.babelrc,package.json}]
+[{.babelrc, package.json, *.yml}]
 indent_size = 2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: Publish Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm install
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test Package
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Cache Node.js modules
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: node-${{ hashFiles('**/package.json') }}
+
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test
+        env:
+          CI: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - 'release/**'
   pull_request:
     branches:
       - master
+      - 'release/**'
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,26 +12,30 @@ on:
 
 jobs:
   build:
+    name: Node ${{ matrix.node-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: ['10.x', '12.x']
     steps:
       - uses: actions/checkout@v2
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Cache Node.js modules
-        uses: actions/cache@v1
+      - uses: actions/cache@v1
         with:
           path: ~/.npm
           key: node-${{ hashFiles('**/package.json') }}
 
-      - run: npm ci
-      - run: npm run build --if-present
-      - run: npm test
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run test with coverage
+        run: npm test -- --coverage
         env:
           CI: true
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 node_modules/
 dist/
 build/
+coverage/
 npm-debug.log
 package-lock.json

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  "roots": [
+    "<rootDir>/src",
+    "<rootDir>/test",
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "compile": "./node_modules/.bin/rollup -c",
     "postcompile": "tsc --emitDeclarationOnly --declaration --outDir ./dist/src",
-    "prepare": "npm run compile"
+    "prepare": "npm run compile",
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -34,7 +35,9 @@
     "@rollup/plugin-json": "^4.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
     "@rollup/plugin-typescript": "^4.0.0",
+    "@types/jest": "^24.0.13",
     "@types/ws": "^6.0.1",
+    "jest": "^24.8.0",
     "rollup-plugin-babel": "^4.3.2",
     "rollup": "^2.4.0",
     "tslint": "^6.1.1",

--- a/test/broadcastt.test.ts
+++ b/test/broadcastt.test.ts
@@ -1,0 +1,3 @@
+test('', () => {
+    expect(true).toBeTruthy();
+});


### PR DESCRIPTION
This PR adds configuration files for GitHub Actions to run test and publish automatically to [NPM registry](https://registry.npmjs.org) when a new release is created.

A secret has to be added with `NPM_TOKEN` name in the settings. The token has to be able to publish the package.